### PR TITLE
Add setMac arg to Wiz5500 constructor to support WIZ550io

### DIFF
--- a/DHCP/README.md
+++ b/DHCP/README.md
@@ -1,7 +1,7 @@
 # Wiznet 5500 DHCP
 
 This library class enables Dynamic Host Configuration Protocol (*DHCP*) functionality for the Wiznet W5500 chip [W5500](http://wizwiki.net/wiki/lib/exe/fetch.php?media=products:w5500:w5500_ds_v106e_141230.pdf). It also requires the Wiznet W5500 driver.
-**To add this code to your project, add `#require W5500.DHCP.device.lib.nut:2.0.0` after `#require W5500.device.lib.nut:2.0.0` to the top of your device code.**
+**To add this code to your project, add `#require W5500.DHCP.device.lib.nut:2.0.0` after `#require W5500.device.lib.nut:2.1.0` to the top of your device code.**
 
 ## Class W5500.DHCP
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library allows you to communicate with a TCP/IP network (separate from an i
 
 This library supports SPI integration with the W5500.
 
-**To use this library, add** `#require "W5500.device.lib.nut:2.0.0"` **to the top of your device code.**
+**To use this library, add** `#require "W5500.device.lib.nut:2.1.0"` **to the top of your device code.**
 
 ## W5500 Class Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library supports SPI integration with the W5500.
 
 ## W5500 Class Usage
 
-### Constructor: W5500(*interruptPin, spi[, csPin][, resetPin][, autoRetry]*)
+### Constructor: W5500(*interruptPin, spi[, csPin][, resetPin][, autoRetry][, setMac]*)
 
 | Parameter | Data Type | Required | Default Value | Description |
 | --- | --- | --- | --- | --- |
@@ -17,6 +17,7 @@ This library supports SPI integration with the W5500.
 | *csPin* | imp **pin** object | No | null | The pin represents a physical pin on the imp and is used to select the SPI bus. On the imp005 if you do not pass a pin into *csPin* you must configure the SPI with the *USE_CS_L* constant |
 | *resetPin* | imp **pin** object | No | N/A| The pin represents a physical pin on the imp and is used for sending a hard reset signal to the W5500 chip |
 | *autoRetry* | Boolean | No | false | Whether the library should automatically retry to open a connection should one fail. **Note** Yet to be implemented |
+| *setMac* | Boolean | No | true | Whether the library should set the MAC address of the chip to the imp's MAC. This should be set to false when using a Wiznet Wiz550io board, since it has its own MAC address |
 
 #### Example
 

--- a/W5500.device.lib.nut
+++ b/W5500.device.lib.nut
@@ -271,7 +271,7 @@ const W5500_INTERRUPT_POLL_TIME_ACTIVE = 0.01;
 
 class W5500 {
 
-    static VERSION = "2.0.0";
+    static VERSION = "2.1.0";
 
     _driver = null;
     _isReady = false; // set to true once the driver is loaded and connection to chip made

--- a/W5500.device.lib.nut
+++ b/W5500.device.lib.nut
@@ -530,7 +530,7 @@ class W5500.Driver {
     //      reset(optional) - configured reset pin
     //      setMac(optional) - set the MAC address of the chip to the imp's MAC
     // ***************************************************************************
-    constructor(interruptPin, spi, cs = null, resetPin = null, setMac = false) {
+    constructor(interruptPin, spi, cs = null, resetPin = null, setMac = true) {
 
         _interruptPin = interruptPin;
         _spi = spi;

--- a/W5500.device.lib.nut
+++ b/W5500.device.lib.nut
@@ -291,11 +291,12 @@ class W5500 {
     //      csPin(optional) -  chip select pin, pass in if not using imp005
     //      resetPin(optional) - reset pin
     //      autoRetry(optional) - not implemented yet.
+    //      setMac(optional) - set the MAC address of the chip to the imp's MAC
     // ***************************************************************************
-    constructor(interruptPin, spi, csPin = null, resetPin = null, autoRetry = false) {
+    constructor(interruptPin, spi, csPin = null, resetPin = null, autoRetry = false, setMac = true) {
 
         // Initialise the driver
-        _driver = W5500.Driver(interruptPin, spi, csPin, resetPin);
+        _driver = W5500.Driver(interruptPin, spi, csPin, resetPin, setMac);
         _driver.init(function() {
 
             // Let the caller know the device is ready
@@ -511,6 +512,7 @@ class W5500.Driver {
     _spi = null;
     _cs = null;
     _resetPin = null;
+    _setMac = null;
 
     _connections = null; // open connections
     _availableSockets = null; // array of sockets available
@@ -526,13 +528,15 @@ class W5500.Driver {
     //      spi - configured spi, W5500 supports spi mode 0 or 3
     //      cs(optional) - configured chip select pin
     //      reset(optional) - configured reset pin
+    //      setMac(optional) - set the MAC address of the chip to the imp's MAC
     // ***************************************************************************
-    constructor(interruptPin, spi, cs = null, resetPin = null) {
+    constructor(interruptPin, spi, cs = null, resetPin = null, setMac = false) {
 
         _interruptPin = interruptPin;
         _spi = spi;
         _cs = cs;
         _resetPin = resetPin;
+        _setMac = setMac;
         _connections = {};
         _availableSockets = [];
 
@@ -644,7 +648,9 @@ class W5500.Driver {
         _interruptPin.configure(DIGITAL_IN_PULLUP, handleInterrupt.bindenv(this));
 
         // Set the default mac address
-        setSourceHWAddr(imp.getmacaddress(), true);
+        if (_setMac){
+            setSourceHWAddr(imp.getmacaddress(), true);
+        }
 
         // Set the defaults
         setNumberOfAvailableSockets(TOTAL_SUPPORTED_SOCKETS);

--- a/example.device.nut
+++ b/example.device.nut
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 
-#require "W5500.device.lib.nut:2.0.0"
+#require "W5500.device.lib.nut:2.1.0"
 
 
 //================================================

--- a/tests/00.W5500.test.nut
+++ b/tests/00.W5500.test.nut
@@ -22,7 +22,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-// #require "W5500.device.lib.nut:2.0.0"
+// #require "W5500.device.lib.nut:2.1.0"
 
 // echo server address and port
 const SOURCE_IP = "192.168.201.185";


### PR DESCRIPTION
@ppetrosh 

I am developing with a [WIZ550io](http://www.wiznet.io/product-item/wiz550io/) board which comes with a built-in MAC address. Because of this, I do not want `W5500.Driver.init` to manually set the MAC address to that of the imp itself. This PR adds as `setMac` optional argument to the constructor of the `W5500` class which allows you to turn off this MAC setting functionality if you want.

I've tested this with my own WIZ550io device. Untested on a stand-alone W5500 chip since I don't have one, but it should not affect things.