### PR TITLE
Fix callback typo on socket interrupt

### DIFF
--- a/W5500.device.lib.nut
+++ b/W5500.device.lib.nut
@@ -2311,7 +2311,7 @@ class W5500.Connection {
             } else {
 
                 local _timeoutCallback = _getHandler("timeout");
-                if (_transmitCallback) {
+                if (_timeoutCallback) {
                     _handlers["timeout"]  <- null;
                     _handlers["transmit"] <- null; // clean the transmit callback as it timed out
 


### PR DESCRIPTION
Ran into an issue today where the Wiznet chip was trying to send a response to its connection, but the message was timing out because the network was disconnected. Instead of correctly handling this timeout, this message was displayed in the console

```
2019-03-07T07:19:58.448 +00:00    [Device]    ERROR: the index '_transmitCallback' does not exist
2019-03-07T07:19:58.449 +00:00    [Device]    ERROR:   in handleInterrupt ...imp#w5500.device.lib.nut#2.1.0:2314
2019-03-07T07:19:58.451 +00:00    [Device]    ERROR:   from handleInterrupt ...imp#w5500.device.lib.nut#2.1.0:1613
```

After looking into this error, it looks like it is due to accidentally referencing a variable which doesn't exist (`_transmitCallback`) rather than the one that was just created (`_timeoutCallback`). Perhaps this was just a typo.