### PR TITLE
Fixed failure to disconnect upon transmit timeout

### DIFF
--- a/W5500.device.lib.nut
+++ b/W5500.device.lib.nut
@@ -2326,6 +2326,22 @@ class W5500.Connection {
                 } else {
                     // server.error("No timeout handler")
                 }
+
+                if( _driver.getSocketStatus(_socket) != W5500_SOCKET_STATUS_ESTABLISHED ) {
+                    _driver.clearSocketInterrupt(_socket, W5500_DISCONNECTED_INT_TYPE);
+                    skip_timer = true;
+
+                    // call disconnected callback
+                    local _disconnectCallback = _getHandler("disconnect");
+                    if (_disconnectCallback) {
+                        imp.wakeup(0, function() {
+                            _disconnectCallback(null);
+                        }.bindenv(this));
+                    }
+
+                    // Close the socket and remove interrupts
+                    close();
+                }
             }
         }
 


### PR DESCRIPTION
Discovered scenarios where a disconnection via pulling the ethernet cable or disabling internet connection sharing results in a transmit timeout but not a disconnection event, leaving the connection open, even though the socket reports as unestablished.

The following fixes this, however, it's possible all transmission timeouts result in the socket to become unestablished but I'm unclear on the exact behaviour and so have placed a check in just in case.