### PR TITLE
Fix an issue with DHCP client identifier (61) option

### DIFF
--- a/DHCP/README.md
+++ b/DHCP/README.md
@@ -1,4 +1,4 @@
-# Wiznet 5500 DHCP 2.0.0 #
+# Wiznet 5500 DHCP 2.0.1 #
 
 This library class enables Dynamic Host Configuration Protocol (DHCP) functionality for the [Wiznet W5500 chip](http://wizwiki.net/wiki/lib/exe/fetch.php?media=products:w5500:w5500_ds_v106e_141230.pdf). It depends on the Wiznet W5500 library, so be sure to include the DHCP library after the W5500 library.
 
@@ -6,7 +6,7 @@ This library class enables Dynamic Host Configuration Protocol (DHCP) functional
 
 ```squirrel
 #require "W5500.device.lib.nut:2.2.0"
-#require "W5500.DHCP.device.lib.nut:2.0.0"
+#require "W5500.DHCP.device.lib.nut:2.0.1"
 ```
 
 ## Class Usage ##

--- a/DHCP/W5500.DHCP.device.lib.nut
+++ b/DHCP/W5500.DHCP.device.lib.nut
@@ -143,7 +143,7 @@ enum W5500_DHCP_OPTIONS {
 
 class W5500.DHCP {
 
-    static VERSION = "2.0.0";
+    static VERSION = "2.0.1";
 
     _driver = null;
     _wiz = null;
@@ -751,6 +751,7 @@ class W5500.DHCP {
         for (local i = 0; i < _mac.len(); i++) {
             mac.writen(_mac[i], 'b');
         }
+        mac.seek(0, 'b');
 
         // OPTIONS
         // Client identifier
@@ -760,7 +761,7 @@ class W5500.DHCP {
         // Type
         options.writen(0x01, 'b');
         // Writes Mac Address
-        options.writeblob(mac);
+        options.writeblob(mac.readblob(6));
 
         // Host Name
         options.writen(W5500_DHCP_OPTIONS.hostName, 'b');

--- a/examples/DHCP_Example.device.nut
+++ b/examples/DHCP_Example.device.nut
@@ -27,7 +27,7 @@
 
 // Include Libraries
 #require "W5500.device.lib.nut:2.2.0"
-#require "W5500.DHCP.device.lib.nut:2.0.0"
+#require "W5500.DHCP.device.lib.nut:2.0.1"
 
 // Configure Echo Server Settings
 const ECHO_SERVER_IP   = "192.168.42.3";


### PR DESCRIPTION
The client identifier option (61) should contain strictly 6 bytes of MAC without any additional padding. Otherwise, there is incompatibility with some DHCP servers.